### PR TITLE
Fix readme and omission of DOCTYPE in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Install the package
 
 ```bash
-npm install -D @garettbland/image-alt-tag-check
+npm install -D @garrettbland/image-alt-tag-check
 ```
 
 Then add the plugin to your `.eleventy.js` file
@@ -15,7 +15,7 @@ Then add the plugin to your `.eleventy.js` file
 ```javascript
 // .eleventy.js
 module.exports = (eleventyConfig) => {
-    eleventyConfig.addPlugin(require('@garettbland/image-alt-tag-check'))
+    eleventyConfig.addPlugin(require('@garrettbland/image-alt-tag-check'))
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ module.exports = (eleventyConfig) => {
                 }
             })
 
-            return document.documentElement.outerHTML
+            return dom.serialize()
         } else {
             return content
         }


### PR DESCRIPTION
- Forgot 'r' in @garrettbland
- As mentioned here: https://github.com/jsdom/jsdom#serializing-the-document-with-serialize, using document.documentElement.outerHTML omits the <!DOCTYPE html>. This commit changes the code to use the dom.serialize() method so <!DOCTYPE html> is included in the output